### PR TITLE
Disabled any multisite settings.

### DIFF
--- a/recaptcha.php
+++ b/recaptcha.php
@@ -520,11 +520,13 @@ JS;
         // add the settings page
         function add_settings_page() {
             // add the options page
+/* huyz 2011-06-15 Doesn't work yet
             if ($this->environment == Environment::WordPressMU && $this->is_authority())
                 add_submenu_page('wpmu-admin.php', 'WP-reCAPTCHA', 'WP-reCAPTCHA', 'manage_options', __FILE__, array(&$this, 'show_settings_page'));
 
             if ($this->environment == Environment::WordPressMS && $this->is_authority())
                 add_submenu_page('ms-admin.php', 'WP-reCAPTCHA', 'WP-reCAPTCHA', 'manage_options', __FILE__, array(&$this, 'show_settings_page'));
+*/
             
             add_options_page('WP-reCAPTCHA', 'WP-reCAPTCHA', 'manage_options', __FILE__, array(&$this, 'show_settings_page'));
         }

--- a/wp-plugin.php
+++ b/wp-plugin.php
@@ -39,7 +39,7 @@ if (!class_exists('WPPlugin')) {
         // environment checking
         static function determine_environment() {
             global $wpmu_version;
-            
+
             if (function_exists('is_multisite'))
                 if (is_multisite())
                     return Environment::WordPressMS;
@@ -91,23 +91,29 @@ if (!class_exists('WPPlugin')) {
         
         // option retrieval
         static function retrieve_options($options_name) {
+/* huyz 2011-06-15 I don't think that's what *site_option is for
             if (WPPlugin::determine_environment() == Environment::WordPressMU || WPPlugin::determine_environment() == Environment::WordPressMS)
                 return get_site_option($options_name);
             else
+*/
                 return get_option($options_name);
         }
         
         static function remove_options($options_name) {
+/* huyz 2011-06-15 I don't think that's what *site_option is for
             if (WPPlugin::determine_environment() == Environment::WordPressMU || WPPlugin::determine_environment() == Environment::WordPressMS)
                 return delete_site_option($options_name);
             else
+*/
                 return delete_option($options_name);
         }
         
         static function add_options($options_name, $options) {
+/* huyz 2011-06-15 I don't think that's what *site_option is for
             if (WPPlugin::determine_environment() == Environment::WordPressMU || WPPlugin::determine_environment() == Environment::WordPressMS)
                 return add_site_option($options_name, $options);
             else
+*/
                 return add_option($options_name, $options);
         }
         


### PR DESCRIPTION
Right now, the implementation for site-wide settings doesn't work.
For details, see
http://wordpress.org/support/topic/doesnt-save-keys-for-wordpress-305

I know that you intend to fix this, so I don't expect you to accept these pull request.
I'm just sending it to you so you know what's not working.

Thanks
