### PR TITLE
WPPlugin::url_to_plugin_directory doesn't work correctly

### DIFF
--- a/recaptcha.php
+++ b/recaptcha.php
@@ -165,9 +165,7 @@ if (!class_exists('reCAPTCHA')) {
         
         // todo: make unnecessary
         function register_stylesheets() {
-            $path = WPPlugin::url_to_plugin_directory() . '/recaptcha.css';
-                
-            echo '<link rel="stylesheet" type="text/css" href="' . $path . '" />';
+            echo '<link rel="stylesheet" type="text/css" href="' . plugins_url('recaptcha.css', __FILE__) . '" />';
         }
         
         // stylesheet information


### PR DESCRIPTION
There is a WordPress library function called [plugins_url](http://codex.wordpress.org/Function_Reference/plugins_url) which works fine. This patch uses the library function.

I ran into this because I'm running the wordpress code from a separate subfolder, as outlined in this blog post: http://davidwinter.me/articles/2012/04/09/install-and-manage-wordpress-with-git/
