### PR TITLE
Use REMOTE_ADDR instead of REMOTEADDR

### DIFF
--- a/recaptcha.php
+++ b/recaptcha.php
@@ -325,7 +325,7 @@ COMMENT_FORM;
                     return $result;
                 }
                 
-                $response = recaptcha_check_answer($this->options['private_key'], $_SERVER['REMOTEADDR'], $_POST['recaptcha_challenge_field'], $_POST['recaptcha_response_field']);
+                $response = recaptcha_check_answer($this->options['private_key'], $_SERVER['REMOTE_ADDR'], $_POST['recaptcha_challenge_field'], $_POST['recaptcha_response_field']);
                 
                 // response is bad, add incorrect response error
                 // todo: why echo the error here? wpmu specific?


### PR DESCRIPTION
This fixes the Captcha submission on Wordpress Multiuser
